### PR TITLE
Fix/travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 before_install:
 - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive
-  texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latex-xcolor
+  texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latex-xcolor lmodern
 script:
 - mkdir _build
 - pdflatex -interaction=nonstopmode -halt-on-error -output-directory _build *.tex

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
-dist: trusty
+dist: focal
 before_install:
 - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive
-  texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latex-xcolor lmodern
+  texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended lmodern
 script:
 - mkdir _build
 - pdflatex -interaction=nonstopmode -halt-on-error -output-directory _build *.tex


### PR DESCRIPTION
1. Install missing package `lmodern` during travis build
2. Upgrade Ubuntu distribution used for travis builds from `trusty (14.04)` to `focal (20.04)`